### PR TITLE
Update cabal-install version

### DIFF
--- a/ghc-7.10.3/Dockerfile
+++ b/ghc-7.10.3/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER John Ky <newhoggy@gmail.com>
 
-ARG GHC_VERSION=8.0.2
+ARG GHC_VERSION=7.10.3
 ARG LTS_SLUG=lts-10.1
 ARG PID1_VERSION=0.1.0.1
 ARG DEBIAN_FRONTEND=noninteractive
@@ -36,7 +36,7 @@ RUN apt-get update                                                          && \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update                                                          && \
-    apt-get -y install alex-3.1.7 cabal-install-2.2 happy-1.19.5            && \
+    apt-get -y install alex-3.1.7 cabal-install-2.4 happy-1.19.5            && \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update                                                          && \

--- a/ghc-8.2.2/Dockerfile
+++ b/ghc-8.2.2/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER John Ky <newhoggy@gmail.com>
 
-ARG GHC_VERSION=8.0.2
+ARG GHC_VERSION=8.2.2
 ARG LTS_SLUG=lts-10.1
 ARG PID1_VERSION=0.1.0.1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ghc-8.4.4/Dockerfile
+++ b/ghc-8.4.4/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER John Ky <newhoggy@gmail.com>
 
+ARG GHC_VERSION=8.4.4
 ARG LTS_SLUG=lts-12.24
 ARG PID1_VERSION=0.1.0.1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ghc-8.6.1/Dockerfile
+++ b/ghc-8.6.1/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER John Ky <newhoggy@gmail.com>
 
+ARG GHC_VERSION=8.6.1
 ARG LTS_SLUG=lts-10.1
 ARG PID1_VERSION=0.1.0.1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ghc-8.6.2/Dockerfile
+++ b/ghc-8.6.2/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER John Ky <newhoggy@gmail.com>
 
+ARG GHC_VERSION=8.6.2
 ARG LTS_SLUG=lts-10.1
 ARG PID1_VERSION=0.1.0.1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ghc-8.6.3/Dockerfile
+++ b/ghc-8.6.3/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER John Ky <newhoggy@gmail.com>
 
+ARG GHC_VERSION=8.6.3
 ARG LTS_SLUG=lts-10.1
 ARG PID1_VERSION=0.1.0.1
 ARG DEBIAN_FRONTEND=noninteractive

--- a/ghc-all/Dockerfile
+++ b/ghc-all/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update                                                          && \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update                                                          && \
-    apt-get -y install alex-3.1.7 cabal-install-2.2 happy-1.19.5            && \
+    apt-get -y install alex-3.1.7 cabal-install-2.4 happy-1.19.5            && \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update                                                          && \


### PR DESCRIPTION
## Changes
- Update `cabal-install` version

### Reason:
`cabal-install-2.2` does not yet contain modern `cabal` commands, such as `v2-*` stuff.
`v2-*` is useful because `new-*` are deprecated and are going to be removed while `v2-*` are promised to stay. 